### PR TITLE
workflow to add bugs to project board

### DIFF
--- a/.github/workflows/add-bugs.yml
+++ b/.github/workflows/add-bugs.yml
@@ -1,0 +1,17 @@
+Add bugs to bugs project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.1.0
+        with:
+          project-url: https://github.com/orgs/netdata/projects/45
+          github-token: ${{ secrets.NETDATABOT_ORG_GITHUB_TOKEN }}
+          labeled: bug


### PR DESCRIPTION
Based on the following the work done on netdata/product to try to put a workflow to automate the moving of new bugs into the Product Bugs project (https://github.com/netdata/product/pull/2962)